### PR TITLE
remove and ignore .hugo_build.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .Rhistory
 .RData
 .Ruserdata
+.hugo_build.lock


### PR DESCRIPTION
`.hugo_build.lock` 是 hugo 构建或预览时产生的空文件，没必要加到源码仓库。

参看：

> The same lock is acquired and released on every hugo build and also all rebuilds when running a server.
>
> —https://discourse.gohugo.io/t/what-is-the-hugo-build-lock-file/35417/3

> Hugo now writes an empty file named .hugo_build.lock to the root of the project when building (also when doing hugo new mypost.md and other commands that requires a build). We recommend you just leave this file alone. **Put it in .gitignore or similar if you don’t want the file in your source repository**.
>
> —https://gohugo.io/news/0.89.0-relnotes/#notes