### PR TITLE
头像覆盖横线

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -104,3 +104,7 @@ span.hash-note::before { content: "　# "; }
     display: none;
   }
 }
+
+.logo img {
+  background: white;
+}


### PR DESCRIPTION
之前的圆形头像周边是透明的，菜单下面的横线就穿过去了。

![image](https://github.com/Shitao5/shitao-blog/assets/60951091/bb14ce6f-6175-40e6-8509-263899898636)

---

添加背景之后是这样的：

![image](https://github.com/Shitao5/shitao-blog/assets/60951091/4947f4c6-700f-445e-97c5-3f4d706c10b2)
