### PR TITLE
修正语言代码，中文标题不用斜体

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 baseurl: https://shitao5.org/
-languageCode: en-us
+languageCode: zh-CN
 title: "Shitao Wu | 吴诗涛"
 theme: paged
 hasCJKLanguage: true

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -108,3 +108,8 @@ span.hash-note::before { content: "　# "; }
 .logo img {
   background: white;
 }
+
+/* 中文没有斜体 */
+h1.title:lang(zh-CN) {
+  font-style: unset;
+}


### PR DESCRIPTION
[中文没有斜体](https://cyrusyip.org/zh-cn/posts/2020/11/26/no-italic-chinese/)

---

修改前：

![Screenshot_20250102_230625](https://github.com/user-attachments/assets/bcbd4ffb-81a7-4261-a412-559ba1f4ab7d)


修改后：

![image](https://github.com/user-attachments/assets/4a5ce37a-1568-476e-a23c-d955d2f9b502)
